### PR TITLE
#4 rotate chosen photos

### DIFF
--- a/app/src/main/java/com/hipaduck/imagerotator/domain/model/Direction.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/domain/model/Direction.kt
@@ -3,5 +3,6 @@ package com.hipaduck.imagerotator.domain.model
 enum class Direction {
     RIGHT,
     LEFT,
-    FLIP_LEFT_AND_RIGHT, FLIP_UPSIDE_DOWN
+    FLIP_HORIZONTAL,
+    FLIP_VERTICAL
 }

--- a/app/src/main/java/com/hipaduck/imagerotator/domain/model/Direction.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/domain/model/Direction.kt
@@ -1,0 +1,7 @@
+package com.hipaduck.imagerotator.domain.model
+
+enum class Direction {
+    RIGHT,
+    LEFT,
+    FLIP_LEFT_AND_RIGHT, FLIP_UPSIDE_DOWN
+}

--- a/app/src/main/java/com/hipaduck/imagerotator/domain/model/MediaStoreFileType.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/domain/model/MediaStoreFileType.kt
@@ -1,0 +1,12 @@
+package com.hipaduck.imagerotator.domain.model
+
+import android.net.Uri
+import android.provider.MediaStore
+
+enum class MediaStoreFileType(
+    val externalContentUri: Uri,
+    val mimeType: String,
+    val pathByPictures: String
+) {
+    IMAGE(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*", "/PhotoRotator"),
+}

--- a/app/src/main/java/com/hipaduck/imagerotator/presentation/extension/Bitmap.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/presentation/extension/Bitmap.kt
@@ -1,0 +1,22 @@
+package com.hipaduck.imagerotator.presentation.extension
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+
+fun Bitmap.rotatedBy(angle: Float): Bitmap {
+    val matrix = Matrix().apply { postRotate(angle) }
+    val originalCopy = this.copy(Bitmap.Config.ARGB_8888, true)
+    return Bitmap.createBitmap(originalCopy, 0, 0, width, height, matrix, true)
+}
+
+fun Bitmap.inverseVerticalBy(): Bitmap {
+    val matrix = Matrix().apply { setScale(1f, -1f) }
+    val originalCopy = this.copy(Bitmap.Config.ARGB_8888, true)
+    return Bitmap.createBitmap(originalCopy, 0, 0, width, height, matrix, true)
+}
+
+fun Bitmap.inverseHorizontalBy(): Bitmap {
+    val matrix = Matrix().apply { setScale(-1f, 1f) }
+    val originalCopy = this.copy(Bitmap.Config.ARGB_8888, true)
+    return Bitmap.createBitmap(originalCopy, 0, 0, width, height, matrix, true)
+}

--- a/app/src/main/java/com/hipaduck/imagerotator/presentation/ui/RotateDialog.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/presentation/ui/RotateDialog.kt
@@ -1,7 +1,6 @@
 package com.hipaduck.imagerotator.presentation.ui
 
 import android.graphics.Bitmap
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -118,7 +117,7 @@ fun RotateDialog(
                                 .height(60.dp),
                             colors = ButtonDefaults.buttonColors(),
                             onClick = {
-                                viewModel.inputDirection(Direction.FLIP_LEFT_AND_RIGHT)
+                                viewModel.inputDirection(Direction.FLIP_HORIZONTAL)
                                 sampleBitmap.value = sampleBitmap.value.inverseHorizontalBy()
                             }) {
                             Image(
@@ -136,7 +135,7 @@ fun RotateDialog(
                                 .height(60.dp),
                             colors = ButtonDefaults.buttonColors(),
                             onClick = {
-                                viewModel.inputDirection(Direction.FLIP_UPSIDE_DOWN)
+                                viewModel.inputDirection(Direction.FLIP_VERTICAL)
                                 sampleBitmap.value = sampleBitmap.value.inverseVerticalBy()
                             }) {
                             Image(
@@ -171,7 +170,6 @@ fun RotateDialog(
 
 @Composable
 fun SampleImage(sampleBitmap: Bitmap) {
-    Log.d("GAEGUL", "sampleBitmap size : ${sampleBitmap.width}, ${sampleBitmap.height}")
     Image(
         bitmap = sampleBitmap.asImageBitmap(),
         contentScale = ContentScale.Crop,

--- a/app/src/main/java/com/hipaduck/imagerotator/presentation/ui/RotateDialog.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/presentation/ui/RotateDialog.kt
@@ -1,0 +1,196 @@
+package com.hipaduck.imagerotator.presentation.ui
+
+import android.graphics.Bitmap
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.hipaduck.imagerotator.R
+import com.hipaduck.imagerotator.domain.model.Direction
+import com.hipaduck.imagerotator.presentation.extension.inverseHorizontalBy
+import com.hipaduck.imagerotator.presentation.extension.inverseVerticalBy
+import com.hipaduck.imagerotator.presentation.extension.rotatedBy
+import com.hipaduck.imagerotator.presentation.viewmodel.MainViewModel
+
+@Composable
+fun RotateDialog(
+    shouldShowDialog: MutableState<Boolean>,
+    viewModel: MainViewModel, // is this right thing to do? cuz hiltViewModel should be called on specific scope i guess
+    bitmap: Bitmap,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    if (shouldShowDialog.value) {
+        val sampleBitmap: MutableState<Bitmap> = remember {
+            mutableStateOf(Bitmap.createBitmap(bitmap))
+        }
+
+        // is this alright? dismiss is called on confirmed too so it's clearing on init.
+        // need to check if this is safe to do
+        viewModel.clearDirections()
+        Dialog(onDismissRequest = onDismiss) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(350.dp)
+                    .padding(8.dp),
+                shape = RoundedCornerShape(16.dp),
+
+                ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .padding(8.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    SampleImage(sampleBitmap.value)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Absolute.SpaceBetween,
+                    ) {
+                        Button(
+                            modifier = Modifier
+                                .width(60.dp)
+                                .height(60.dp),
+                            colors = ButtonDefaults.buttonColors(),
+                            onClick = {
+                                viewModel.inputDirection(Direction.RIGHT)
+                                sampleBitmap.value = sampleBitmap.value.rotatedBy(90f)
+                            }) {
+                            Image(
+                                painter = painterResource(id = R.drawable.rotate_right),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                            )
+                        }
+                        Button(
+                            modifier = Modifier
+                                .width(60.dp)
+                                .height(60.dp),
+                            colors = ButtonDefaults.buttonColors(),
+                            onClick = {
+                                viewModel.inputDirection(Direction.LEFT)
+                                sampleBitmap.value = sampleBitmap.value.rotatedBy(-90f)
+                            }) {
+                            Image(
+                                painter = painterResource(id = R.drawable.rotate_left),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                            )
+
+                        }
+                        Button(
+                            modifier = Modifier
+                                .width(60.dp)
+                                .height(60.dp),
+                            colors = ButtonDefaults.buttonColors(),
+                            onClick = {
+                                viewModel.inputDirection(Direction.FLIP_LEFT_AND_RIGHT)
+                                sampleBitmap.value = sampleBitmap.value.inverseHorizontalBy()
+                            }) {
+                            Image(
+                                painter = painterResource(id = R.drawable.flip_left_right),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                            )
+
+                        }
+                        Button(
+                            modifier = Modifier
+                                .width(60.dp)
+                                .height(60.dp),
+                            colors = ButtonDefaults.buttonColors(),
+                            onClick = {
+                                viewModel.inputDirection(Direction.FLIP_UPSIDE_DOWN)
+                                sampleBitmap.value = sampleBitmap.value.inverseVerticalBy()
+                            }) {
+                            Image(
+                                painter = painterResource(id = R.drawable.flip_upside_down),
+                                contentDescription = null,
+                                contentScale = ContentScale.Fit,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                            )
+
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Absolute.SpaceBetween
+                    ) {
+                        TextButton(onClick = { onDismiss() }) {
+                            Text("Cancel")
+                        }
+                        TextButton(onClick = { onConfirm() }) {
+                            Text("Confirm")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SampleImage(sampleBitmap: Bitmap) {
+    Log.d("GAEGUL", "sampleBitmap size : ${sampleBitmap.width}, ${sampleBitmap.height}")
+    Image(
+        bitmap = sampleBitmap.asImageBitmap(),
+        contentScale = ContentScale.Crop,
+        contentDescription = null,
+        modifier = Modifier
+            .height(150.dp)
+            .width(((sampleBitmap.width.toFloat() / sampleBitmap.height.toFloat()) * 150).dp)
+    )
+}
+
+// no can do with viewmodel
+//@Preview
+//@Composable
+//fun AlertDialogExamplePreview() {
+//    RotateDialog(
+//        shouldShowDialog = remember { mutableStateOf(true) },
+//        onDismiss = {},
+//        onConfirm = {},
+//        viewModel = hiltViewModel(),
+//        photo = Photo("tmp", "https://picsum.photos/")
+//    )
+//}

--- a/app/src/main/java/com/hipaduck/imagerotator/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/presentation/viewmodel/MainViewModel.kt
@@ -1,17 +1,40 @@
 package com.hipaduck.imagerotator.presentation.viewmodel
 
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageDecoder
 import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
+import com.hipaduck.imagerotator.R
+import com.hipaduck.imagerotator.domain.model.Direction
+import com.hipaduck.imagerotator.domain.model.MediaStoreFileType
 import com.hipaduck.imagerotator.domain.model.Photo
+import com.hipaduck.imagerotator.presentation.extension.inverseHorizontalBy
+import com.hipaduck.imagerotator.presentation.extension.inverseVerticalBy
+import com.hipaduck.imagerotator.presentation.extension.rotatedBy
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Locale
 import java.util.Random
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor() : ViewModel() {
+class MainViewModel @Inject constructor(@ApplicationContext private val applicationContext: Context) :
+    ViewModel() {
     private val _text = MutableStateFlow("Hello, Compose")
     val text: StateFlow<String>
         get() = _text
@@ -22,6 +45,8 @@ class MainViewModel @Inject constructor() : ViewModel() {
 
     // 외부에서 가져온 이미지들을 보관
     private val fetchedImages = mutableListOf<Uri>()
+
+    private val directionControls = mutableListOf<Direction>()
 
     fun fetchSelectedImage(uris: List<Uri>) {
         fetchedImages.clear()
@@ -66,4 +91,172 @@ class MainViewModel @Inject constructor() : ViewModel() {
         }
         _photoList.value = photoList
     }
+
+    fun inputDirection(direction: Direction) {
+        // input direction saves values from here
+        directionControls.add(direction)
+    }
+
+    fun clearDirections() {
+        // when complete or cancel, clear values from here
+        directionControls.clear()
+        // TODO: simplify control if we can
+    }
+
+    fun rotateSavePhotos() {
+        // before dismissing,rotate photos
+
+        for (photo in _photoList.value) {
+            val bitmap = editPhotoByDirectionControls(Uri.parse(photo.url))
+            processOnBitmapReady(bitmap)
+        }
+
+        // TODO: maybe show loading status to block user's interaction or etc
+
+        // clear every thing when it's ready
+        clearDirections()
+        _photoList.value = emptyList()
+    }
+
+    private fun processOnBitmapReady(saveBitmap: Bitmap?): Uri {
+        val stream = ByteArrayOutputStream()
+
+        saveBitmap?.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+        val byteArray = stream.toByteArray()
+        val fileName = SimpleDateFormat(
+            "yyyyMMdd_HHmmssSSS",
+            Locale.getDefault()
+        ).format(System.currentTimeMillis()) + ".jpg"
+        val outUri: Uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            createFile(fileName, MediaStoreFileType.IMAGE, byteArray)
+        } else {
+            createFileBeforeAndroidQ(fileName, MediaStoreFileType.IMAGE, byteArray)
+        }
+
+        saveBitmap?.recycle()
+        return outUri
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    fun createFile(fileName: String, fileType: MediaStoreFileType, fileContents: ByteArray): Uri {
+        val contentValues = ContentValues()
+
+        with(contentValues) {
+            when (fileType) {
+                MediaStoreFileType.IMAGE -> {
+                    put(
+                        MediaStore.Files.FileColumns.RELATIVE_PATH,
+                        Environment.DIRECTORY_PICTURES + fileType.pathByPictures
+                    )
+                }
+            }
+            put(MediaStore.Files.FileColumns.DISPLAY_NAME, fileName)
+            put(MediaStore.Files.FileColumns.MIME_TYPE, fileType.mimeType)
+            put(MediaStore.Files.FileColumns.IS_PENDING, 1)
+        }
+
+        val uri = applicationContext.contentResolver.insert(
+            fileType.externalContentUri,
+            contentValues
+        )
+
+        val parcelFileDescriptor =
+            applicationContext.contentResolver.openFileDescriptor(uri!!, "w", null)
+
+        val fileOutputStream = FileOutputStream(parcelFileDescriptor!!.fileDescriptor)
+        fileOutputStream.write(fileContents)
+        fileOutputStream.close()
+
+        with(contentValues) {
+            clear()
+            put(MediaStore.Files.FileColumns.IS_PENDING, 0)
+        }
+        applicationContext.contentResolver.update(uri, contentValues, null, null)
+
+        return uri
+    }
+
+    private fun createFileBeforeAndroidQ(
+        fileName: String,
+        fileType: MediaStoreFileType,
+        fileContents: ByteArray
+    ): Uri {
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+            .toString() + File.separator + fileType.pathByPictures
+        val file = File(dir)
+        if (!file.exists()) {
+            file.mkdirs()
+        }
+
+        val imgFile = File(file, fileName)
+        val fileOutputStream = FileOutputStream(imgFile)
+        fileOutputStream.write(fileContents)
+        fileOutputStream.close()
+
+        val values = ContentValues()
+        with(values) {
+            put(MediaStore.Images.Media.TITLE, fileName)
+            put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis())
+            put(MediaStore.Images.Media.DATA, imgFile.absolutePath)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        }
+
+        val uri = applicationContext.contentResolver.insert(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            values
+        )
+        return uri!!
+    }
+
+    private fun editPhotoByDirectionControls(uri: Uri): Bitmap? {
+        var editedBitmap = getBitmapFromUri(uri) ?: return null
+        for (direction in directionControls) {
+            when (direction) {
+                Direction.RIGHT -> {
+                    editedBitmap = editedBitmap.rotatedBy(90.0f)
+                }
+
+                Direction.LEFT -> {
+                    editedBitmap = editedBitmap.rotatedBy(-90.0f)
+                }
+
+                Direction.FLIP_UPSIDE_DOWN -> {
+                    editedBitmap = editedBitmap.inverseVerticalBy()
+                }
+
+                else -> { // FLIP_LEFT_AND_RIGHT
+                    editedBitmap = editedBitmap.inverseHorizontalBy()
+                }
+            }
+        }
+        return editedBitmap
+    }
+
+    fun getDefaultBitmap(): Bitmap {
+        return BitmapFactory.decodeResource(
+            applicationContext.resources,
+            R.drawable.ic_launcher_foreground
+        )
+    }
+
+    fun getBitmapFromUri(uri: Uri): Bitmap? {
+        try {
+            return if (Build.VERSION.SDK_INT < 28) {
+                MediaStore.Images.Media.getBitmap(
+                    applicationContext.contentResolver,
+                    uri
+                )
+            } else {
+                val source =
+                    ImageDecoder.createSource(applicationContext.contentResolver, uri)
+                ImageDecoder.decodeBitmap(source)
+            }
+        } catch (e: IOException) {
+            return null
+        }
+    }
+
+    private fun savePhotos() {}
+
+    private fun showToastMessage(message: String) {}
 }

--- a/app/src/main/java/com/hipaduck/imagerotator/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hipaduck/imagerotator/presentation/viewmodel/MainViewModel.kt
@@ -220,7 +220,7 @@ class MainViewModel @Inject constructor(@ApplicationContext private val applicat
                     editedBitmap = editedBitmap.rotatedBy(-90.0f)
                 }
 
-                Direction.FLIP_UPSIDE_DOWN -> {
+                Direction.FLIP_VERTICAL -> {
                     editedBitmap = editedBitmap.inverseVerticalBy()
                 }
 


### PR DESCRIPTION
rotate chosen photos
- `+ button` will only shown when images are in the queue
- dialog will shown when user clicks `+ button`
- when user rotates bitmap with button, it will show sample img with last one in the list
- when it's confirmed, it will clear all and save edited images